### PR TITLE
Replace newlines in the payload JSON with the \n escape sequence.

### DIFF
--- a/git-slack-hook
+++ b/git-slack-hook
@@ -244,7 +244,7 @@ function notify() {
 
     # Process the log and escape double quotes and backslashes; assuming commit names/messages don't have five of the following: & ; @
     log_out=$( git log --pretty=format:"&&&&&%cN;;;;;${formattedurl}${commitformat}@@@@@" $countarg ${start}..${end} \
-        | sed ':a;N;$!ba;s/\n+/\\n/g' \
+        | perl -p -e 's/@@@@@\n+/@@@@@/mg' \
         | sed -e 's/\\/\\\\/g' \
         | sed -e 's/"/\\"/g' \
         | sed -e 's/&&&&&\(.*\);;;;;/{ \"fallback\" : \"\", \"color\" : \"good\", \"fields\" : [{"title":"\1","value":"/g' \
@@ -262,7 +262,7 @@ function notify() {
   fi
 
   # slack API uses \n substitution for newlines
-  # msg=$(echo "${msg}" | perl -p -e 's/\+/&#43;/mg')
+  msg=$(echo -n "${msg}" | perl -p -e 's/\n/\\n/mg')
 
   webhook_url=$(git config --get hooks.slack.webhook-url)
   channel=$(git config --get hooks.slack.channel)


### PR DESCRIPTION
Today I ran into a problem with Slack rejecting commit messages with an "invalid_payload" error. I discovered that the script was embedding raw newlines in the JSON being sent to Slack. The raw newlines in the JSON result in invalid JSON. The script was working fine until today, so I assume that Slack has become more stringent with what they will accept for JSON. Slack has since rolled back this change, so the existing script still works, but is still sending invalid JSON.

The commit I've made does two things. First, on line 247 I strip newlines from the end of every commit, not just the end of the last commit. Second, on line 265 I replace raw newline characters with the \n escape sequence. The change on line 247 is required by the change on line 265, otherwise you get the \n escape sequence in your payload JSON in between commits.

I am submitting this pull request against your fork, rather than chriseldredge's original version, since I am relying upon your multiline commit message fix for my own needs and my subsequent fix is also dependent on your fix.